### PR TITLE
Add Docker support with graceful shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Multi-stage build for pocket-tts with pre-downloaded models
+FROM rust:1.92-bullseye AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy workspace files
+COPY ./ ./
+
+# Build the project in release mode
+RUN cargo build --release
+
+# =============================================================================
+# Runtime with manual downloads
+# =============================================================================
+FROM debian:bullseye-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl1.1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/pocket-tts-cli /usr/local/bin/pocket-tts
+COPY --from=builder /build/crates/pocket-tts/config /app/config
+
+# Patch the config to use the public (no-auth) model path as the default
+# This makes it use weights_path_without_voice_cloning instead of weights_path
+RUN sed -i 's|^weights_path: hf://kyutai/pocket-tts/|#weights_path: hf://kyutai/pocket-tts/|' /app/config/b6369a24.yaml && \
+    sed -i 's|^weights_path_without_voice_cloning:|weights_path:|' /app/config/b6369a24.yaml
+
+WORKDIR /app
+
+# Run the tool once during build to let hf_hub download and create proper cache structure
+# This creates all the blob files, refs, and metadata that hf_hub needs for offline operation
+# Generate with all available voices to cache all voice embeddings
+RUN for voice in alba marius javert jean fantine cosette eponine azelma; do \
+        echo "Caching voice: $voice"; \
+        pocket-tts generate --text "Initialize cache" --voice "$voice" && rm -f output.wav; \
+    done
+
+EXPOSE 8000
+
+ENTRYPOINT ["pocket-tts"]
+CMD ["serve", "--host", "0.0.0.0", "--port", "8000"]

--- a/crates/pocket-tts-cli/src/server/mod.rs
+++ b/crates/pocket-tts-cli/src/server/mod.rs
@@ -55,7 +55,41 @@ pub async fn start_server(args: ServeArgs) -> Result<()> {
     print_endpoints(&args.host, args.port);
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    axum::serve(listener, app).await?;
+    
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    println!("  👋 Server stopped gracefully");
 
     Ok(())
+}
+
+/// Wait for Ctrl+C or SIGTERM signal
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {
+            println!("\n  ⚠️  Received Ctrl+C, shutting down...");
+        },
+        _ = terminate => {
+            println!("\n  ⚠️  Received SIGTERM, shutting down...");
+        },
+    }
 }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,130 @@
+# Docker Deployment Guide
+
+This document describes the Dockerfile for `pocket-tts` (Rust/Candle) and how to use it for containerized deployment.
+
+## Overview
+
+The Dockerfile uses a multi-stage build approach to create a minimal production image with pre-downloaded models, **enabling completely offline operation** without requiring a HuggingFace token or internet access at runtime.
+
+This means that the container *does not* support voice cloning, as the voice cloning model weights are gated and require authentication.
+
+## Quick Start
+
+### Build the Image
+
+```bash
+docker build -t pocket-tts .
+```
+
+This will take several minutes as it downloads the base image and model weights (~300MB) and builds the server.
+
+### Run the Server
+
+```bash
+docker run -p 8000:8000 pocket-tts
+```
+
+Access the web UI at `http://localhost:8000`.
+
+### Verify Offline Operation
+
+To confirm the container runs completely offline without internet access:
+
+```bash
+# Generate audio completely offline
+docker run --network none pocket-tts generate --text "Testing offline mode" --voice alba
+```
+
+## Build Stages
+
+### Stage 1: Builder (rust:1.92-bullseye)
+
+The builder stage:
+- Installs build dependencies (cmake)
+- Copies the entire workspace
+- Builds the project in release mode using `cargo build --release`
+
+### Stage 2: Runtime (debian:bullseye-slim)
+
+The runtime stage creates a minimal image by:
+- Installing only essential runtime dependencies:
+  - `ca-certificates`: Required for HTTPS connections
+  - `libssl1.1`: OpenSSL library for secure connections
+- Copying the compiled binary (`pocket-tts-cli`) from the builder stage
+- Copying the configuration files from `crates/pocket-tts/config`
+
+## Model Caching Strategy
+
+The Dockerfile implements a clever model pre-caching strategy to enable offline operation:
+
+### Config Patching
+
+The build process patches the configuration file to use the public (no-auth) model path:
+```bash
+sed -i 's|^weights_path: hf://kyutai/pocket-tts/|#weights_path: hf://kyutai/pocket-tts/|' /app/config/b6369a24.yaml
+sed -i 's|^weights_path_without_voice_cloning:|weights_path:|' /app/config/b6369a24.yaml
+```
+
+This changes the default `weights_path` to use the non-gated model variant, eliminating the need for `HF_TOKEN` at runtime.
+
+### Voice Embedding Pre-Cache
+
+The build process generates audio for each available voice to pre-cache all voice embeddings:
+```bash
+for voice in alba marius javert jean fantine cosette eponine azelma; do
+    pocket-tts generate --text "Initialize cache" --voice "$voice" && rm -f output.wav
+done
+```
+
+This ensures:
+- All model weights are downloaded during build time
+- All voice embeddings are cached in the HuggingFace Hub cache
+- The container can run completely offline without requiring internet access
+- No authentication token is needed at runtime
+
+## Detailed Usage
+
+### Running CLI Commands
+
+Thanks to the `ENTRYPOINT`, you can run CLI commands directly without repeating the binary name:
+
+```bash
+# Generate audio
+docker run pocket-tts generate --text "Hello world" --voice alba
+
+# Show help
+docker run pocket-tts --help
+
+# List available voices
+docker run pocket-tts generate --help
+```
+
+To extract the generated audio file:
+```bash
+docker run -v $(pwd):/output:z pocket-tts generate --text "Hello world" --voice alba --output /output/hello.wav
+```
+
+## Available Voices
+
+The following voices are pre-cached in the image:
+- `alba`
+- `marius`
+- `javert`
+- `jean`
+- `fantine`
+- `cosette`
+- `eponine`
+- `azelma`
+
+## Image Size Considerations
+
+The final image size is **339MB**, with the following layer breakdown:
+
+- **Debian base system**: 80.7MB (debian:bullseye-slim)
+- **Runtime dependencies**: 3.08MB (ca-certificates, libssl1.1)
+- **Compiled binary**: 15.4MB (pocket-tts-cli release build)
+- **Configuration files**: ~1.3KB (YAML config)
+- **Cached models & voice embeddings**: 240MB (all weights and 8 voice embeddings)
+
+The image is considerably smaller than usual machine learning images, coming in at under 340MB total despite including all model weights and voice embeddings for offline operation. There is of course
+a lot of room for improvement (smaller base image, model quantization, etc), but this is a solid starting point for a fully offline TTS Docker image.


### PR DESCRIPTION
## Summary

Adds Docker support with offline operation and graceful shutdown handling.

### Changes

**Dockerfile:**
- Multi-stage build with 339MB final image
- Pre-caches all model weights and 8 voice embeddings at build time
- Completely offline operation (no HuggingFace token or internet needed)
- Uses public model weights (no voice cloning support to avoid gated weights)

**Server:**
- Graceful shutdown on Ctrl+C/SIGTERM signals
- Proper resource cleanup on container stop

**Documentation:**
- Comprehensive guide in `docs/docker.md`
- Quick start and usage examples

### Technical Notes

**Voice Cloning:** Not supported in the Docker build. This allows using the public (non-gated) model weights, enabling completely offline operation without authentication.

**Config Patching:** Currently uses `sed` to patch the YAML config during build, which is a bit hacky but works. Happy to implement a cleaner approach (separate config file, environment-based selection, etc.) if you have preferences.

**Image Size:**
- Debian base: 80.7MB
- Runtime deps: 3.08MB  
- Binary: 15.4MB
- Models/voices: 240MB

### Testing

```bash
docker build -t pocket-tts .
docker run -p 8000:8000 pocket-tts
docker run --network none pocket-tts generate --text "Offline test" --voice alba
```