### PR TITLE
Replace sentencepiece with tokenizers crate to fix protobuf conflict

### DIFF
--- a/crates/pocket-tts/Cargo.toml
+++ b/crates/pocket-tts/Cargo.toml
@@ -47,7 +47,8 @@ tracing.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 hf-hub.workspace = true
 memmap2.workspace = true
-sentencepiece = "0.13"
+# sentencepiece removed - causes protobuf conflict with onnxruntime
+# Using tokenizers crate's built-in SentencePiece support instead
 tokenizers = { workspace = true, features = ["onig", "progressbar", "http"] }
 intel-mkl-src.workspace = true
 

--- a/crates/pocket-tts/src/conditioners/text.rs
+++ b/crates/pocket-tts/src/conditioners/text.rs
@@ -1,10 +1,7 @@
 use candle_core::Tensor;
 use candle_nn::{Embedding, Module, VarBuilder};
 
-#[cfg(not(target_arch = "wasm32"))]
-use sentencepiece::SentencePieceProcessor;
-
-#[cfg(target_arch = "wasm32")]
+// Use tokenizers crate for all platforms (no protobuf dependency)
 use tokenizers::Tokenizer;
 
 use anyhow::Result;
@@ -14,9 +11,6 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct LUTConditioner {
-    #[cfg(not(target_arch = "wasm32"))]
-    sp: Arc<SentencePieceProcessor>,
-    #[cfg(target_arch = "wasm32")]
     tokenizer: Arc<Tokenizer>,
     embed: Embedding,
 }
@@ -29,43 +23,221 @@ impl LUTConditioner {
         _output_dim: usize,
         vb: VarBuilder,
     ) -> Result<Self> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let sp = SentencePieceProcessor::open(tokenizer_path)
-                .map_err(|e| anyhow::anyhow!("Failed to load tokenizer: {:?}", e))?;
+        // Load SentencePiece model using tokenizers crate
+        // The tokenizers crate can load .model files directly via from_file
+        // For .model files, we need to use the unigram model loader
+        let tokenizer = if tokenizer_path.extension().is_some_and(|e| e == "model") {
+            // SentencePiece .model file - use unigram loader
+            Self::load_sentencepiece_model(tokenizer_path)?
+        } else {
+            // JSON tokenizer file
+            Tokenizer::from_file(tokenizer_path)
+                .map_err(|e| anyhow::anyhow!("Failed to load tokenizer from file: {:?}", e))?
+        };
 
-            // Verify vocab size matches
-            let vocab_size = sp.len();
-            if vocab_size != n_bins {
-                anyhow::bail!(
-                    "Tokenizer vocab size {} doesn't match n_bins {}",
-                    vocab_size,
-                    n_bins
-                );
+        // Verify vocab size matches
+        let vocab_size = tokenizer.get_vocab_size(true);
+        if vocab_size != n_bins {
+            anyhow::bail!(
+                "Tokenizer vocab size {} doesn't match n_bins {}",
+                vocab_size,
+                n_bins
+            );
+        }
+
+        // n_bins + 1 for padding
+        let embed = candle_nn::embedding(n_bins + 1, dim, vb.pp("embed"))?;
+
+        Ok(Self {
+            tokenizer: Arc::new(tokenizer),
+            embed,
+        })
+    }
+
+    /// Load a SentencePiece .model file using tokenizers crate
+    fn load_sentencepiece_model(path: &Path) -> Result<Tokenizer> {
+        use tokenizers::models::unigram::Unigram;
+        use tokenizers::pre_tokenizers::metaspace::{Metaspace, PrependScheme};
+
+        // Read the protobuf file and extract vocab manually
+        // The tokenizers crate's Unigram model can be built from vocab
+        let model_bytes =
+            std::fs::read(path).map_err(|e| anyhow::anyhow!("Failed to read model file: {}", e))?;
+
+        // Parse SentencePiece model protobuf to extract vocab
+        let (vocab, unk_id) = Self::parse_sentencepiece_vocab(&model_bytes)?;
+
+        // Build Unigram model from vocab
+        let unigram = Unigram::from(vocab, Some(unk_id), true)
+            .map_err(|e| anyhow::anyhow!("Failed to create unigram model: {:?}", e))?;
+
+        // Build tokenizer with SentencePiece-style settings
+        let mut tokenizer = Tokenizer::new(unigram);
+        tokenizer.with_pre_tokenizer(Some(Metaspace::new('▁', PrependScheme::Always, false)));
+        tokenizer.with_decoder(Some(Metaspace::new('▁', PrependScheme::Always, false)));
+
+        Ok(tokenizer)
+    }
+
+    /// Parse SentencePiece model protobuf to extract vocabulary
+    /// SentencePiece uses a simple protobuf format we can parse manually
+    fn parse_sentencepiece_vocab(data: &[u8]) -> Result<(Vec<(String, f64)>, usize)> {
+        // SentencePiece protobuf structure (simplified):
+        // message ModelProto {
+        //   repeated SentencePiece pieces = 1;
+        //   ...
+        // }
+        // message SentencePiece {
+        //   optional string piece = 1;
+        //   optional float score = 2;
+        //   ...
+        // }
+        //
+        // We parse field 1 (pieces) which contains repeated messages with piece (field 1) and score (field 2)
+
+        let mut vocab = Vec::new();
+        let mut unk_id = 0usize;
+        let mut pos = 0;
+
+        while pos < data.len() {
+            // Read field tag
+            let (tag, new_pos) = Self::read_varint(data, pos)?;
+            pos = new_pos;
+
+            let field_number = tag >> 3;
+            let wire_type = tag & 0x7;
+
+            match (field_number, wire_type) {
+                (1, 2) => {
+                    // Field 1 (pieces), wire type 2 (length-delimited) - this is a SentencePiece message
+                    let (len, new_pos) = Self::read_varint(data, pos)?;
+                    pos = new_pos;
+                    let end = pos + len as usize;
+
+                    // Parse the nested SentencePiece message
+                    let mut piece = String::new();
+                    let mut score = 0.0f64;
+                    let mut inner_pos = pos;
+
+                    while inner_pos < end {
+                        let (inner_tag, new_inner_pos) = Self::read_varint(data, inner_pos)?;
+                        inner_pos = new_inner_pos;
+
+                        let inner_field = inner_tag >> 3;
+                        let inner_wire = inner_tag & 0x7;
+
+                        match (inner_field, inner_wire) {
+                            (1, 2) => {
+                                // piece string
+                                let (len, new_pos) = Self::read_varint(data, inner_pos)?;
+                                inner_pos = new_pos;
+                                piece = String::from_utf8_lossy(
+                                    &data[inner_pos..inner_pos + len as usize],
+                                )
+                                .to_string();
+                                inner_pos += len as usize;
+                            }
+                            (2, 5) => {
+                                // score (float, wire type 5 = 32-bit)
+                                if inner_pos + 4 <= data.len() {
+                                    let bytes: [u8; 4] =
+                                        data[inner_pos..inner_pos + 4].try_into().unwrap();
+                                    score = f32::from_le_bytes(bytes) as f64;
+                                    inner_pos += 4;
+                                }
+                            }
+                            (3, 0) => {
+                                // type (varint)
+                                let (type_val, new_pos) = Self::read_varint(data, inner_pos)?;
+                                inner_pos = new_pos;
+                                // type 2 = UNKNOWN
+                                if type_val == 2 {
+                                    unk_id = vocab.len();
+                                }
+                            }
+                            (_, 0) => {
+                                // Other varint field - skip
+                                let (_, new_pos) = Self::read_varint(data, inner_pos)?;
+                                inner_pos = new_pos;
+                            }
+                            (_, 2) => {
+                                // Other length-delimited field - skip
+                                let (len, new_pos) = Self::read_varint(data, inner_pos)?;
+                                inner_pos = new_pos + len as usize;
+                            }
+                            (_, 5) => {
+                                // 32-bit field - skip
+                                inner_pos += 4;
+                            }
+                            (_, 1) => {
+                                // 64-bit field - skip
+                                inner_pos += 8;
+                            }
+                            _ => {
+                                // Unknown wire type - try to skip
+                                inner_pos = end;
+                            }
+                        }
+                    }
+
+                    if !piece.is_empty() {
+                        vocab.push((piece, score));
+                    }
+                    pos = end;
+                }
+                (_, 0) => {
+                    // Varint - skip
+                    let (_, new_pos) = Self::read_varint(data, pos)?;
+                    pos = new_pos;
+                }
+                (_, 2) => {
+                    // Length-delimited - skip
+                    let (len, new_pos) = Self::read_varint(data, pos)?;
+                    pos = new_pos + len as usize;
+                }
+                (_, 5) => {
+                    // 32-bit - skip
+                    pos += 4;
+                }
+                (_, 1) => {
+                    // 64-bit - skip
+                    pos += 8;
+                }
+                _ => {
+                    break; // Unknown wire type
+                }
             }
-
-            // n_bins + 1 for padding
-            let embed = candle_nn::embedding(n_bins + 1, dim, vb.pp("embed"))?;
-
-            Ok(Self {
-                sp: Arc::new(sp),
-                embed,
-            })
         }
 
-        #[cfg(target_arch = "wasm32")]
-        {
-            // Note: Tokenizer::from_file on WASM might have issues with local paths.
-            // In a real WASM app, you'd likely load from bytes.
-            let tokenizer = Tokenizer::from_file(tokenizer_path)
-                .map_err(|e| anyhow::anyhow!("Failed to load tokenizer from file: {:?}", e))?;
-            let tokenizer = Arc::new(tokenizer);
-
-            // n_bins + 1 for padding
-            let embed = candle_nn::embedding(n_bins + 1, dim, vb.pp("embed"))?;
-
-            Ok(Self { tokenizer, embed })
+        if vocab.is_empty() {
+            anyhow::bail!("No vocabulary found in SentencePiece model");
         }
+
+        Ok((vocab, unk_id))
+    }
+
+    /// Read a varint from the buffer
+    fn read_varint(data: &[u8], mut pos: usize) -> Result<(u64, usize)> {
+        let mut result = 0u64;
+        let mut shift = 0;
+
+        loop {
+            if pos >= data.len() {
+                anyhow::bail!("Unexpected end of data while reading varint");
+            }
+            let byte = data[pos];
+            pos += 1;
+            result |= ((byte & 0x7F) as u64) << shift;
+            if byte & 0x80 == 0 {
+                break;
+            }
+            shift += 7;
+            if shift >= 64 {
+                anyhow::bail!("Varint too large");
+            }
+        }
+
+        Ok((result, pos))
     }
 
     /// Create LUTConditioner from pre-loaded tokenizer bytes (useful for WASM)
@@ -76,47 +248,42 @@ impl LUTConditioner {
         _output_dim: usize,
         vb: VarBuilder,
     ) -> Result<Self> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let _ = (n_bins, tokenizer_bytes, dim, vb);
-            anyhow::bail!("new_from_bytes not implemented for non-wasm target (sentencepiece)");
-        }
+        // Try to parse as JSON tokenizer first
+        let tokenizer = if let Ok(t) = Tokenizer::from_bytes(tokenizer_bytes) {
+            t
+        } else {
+            // Try as SentencePiece model
+            let (vocab, unk_id) = Self::parse_sentencepiece_vocab(tokenizer_bytes)?;
 
-        #[cfg(target_arch = "wasm32")]
-        {
-            let tokenizer = Tokenizer::from_bytes(tokenizer_bytes)
-                .map_err(|e| anyhow::anyhow!("Failed to load tokenizer from bytes: {:?}", e))?;
-            let tokenizer = Arc::new(tokenizer);
+            use tokenizers::models::unigram::Unigram;
+            use tokenizers::pre_tokenizers::metaspace::{Metaspace, PrependScheme};
 
-            // n_bins + 1 for padding
-            let embed = candle_nn::embedding(n_bins + 1, dim, vb.pp("embed"))?;
+            let unigram = Unigram::from(vocab, Some(unk_id), true)
+                .map_err(|e| anyhow::anyhow!("Failed to create unigram model: {:?}", e))?;
 
-            Ok(Self { tokenizer, embed })
-        }
+            let mut tok = Tokenizer::new(unigram);
+            tok.with_pre_tokenizer(Some(Metaspace::new('▁', PrependScheme::Always, false)));
+            tok.with_decoder(Some(Metaspace::new('▁', PrependScheme::Always, false)));
+            tok
+        };
+
+        // n_bins + 1 for padding
+        let embed = candle_nn::embedding(n_bins + 1, dim, vb.pp("embed"))?;
+
+        Ok(Self {
+            tokenizer: Arc::new(tokenizer),
+            embed,
+        })
     }
 
     pub fn prepare(&self, text: &str, device: &candle_core::Device) -> Result<Tensor> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let pieces = self
-                .sp
-                .encode(text)
-                .map_err(|e| anyhow::anyhow!("Failed to encode text: {:?}", e))?;
+        let encoding = self
+            .tokenizer
+            .encode(text, true)
+            .map_err(|e| anyhow::anyhow!("Failed to encode text: {:?}", e))?;
 
-            let ids: Vec<u32> = pieces.iter().map(|p| p.id).collect();
-            Ok(Tensor::from_vec(ids.clone(), (1, ids.len()), device)?)
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            let encoding = self
-                .tokenizer
-                .encode(text, true)
-                .map_err(|e| anyhow::anyhow!("Failed to encode text: {:?}", e))?;
-
-            let ids = encoding.get_ids();
-            Ok(Tensor::from_vec(ids.to_vec(), (1, ids.len()), device)?)
-        }
+        let ids = encoding.get_ids();
+        Ok(Tensor::from_vec(ids.to_vec(), (1, ids.len()), device)?)
     }
 
     pub fn forward(&self, tokens: &Tensor) -> Result<Tensor> {
@@ -138,22 +305,10 @@ impl LUTConditioner {
     /// Count tokens in a text string without creating tensors.
     /// Used for accurate text splitting to avoid oversized chunks.
     pub fn count_tokens(&self, text: &str) -> Result<usize> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let pieces = self
-                .sp
-                .encode(text)
-                .map_err(|e| anyhow::anyhow!("Failed to encode text: {:?}", e))?;
-            Ok(pieces.len())
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            let encoding = self
-                .tokenizer
-                .encode(text, true)
-                .map_err(|e| anyhow::anyhow!("Failed to encode text: {:?}", e))?;
-            Ok(encoding.get_ids().len())
-        }
+        let encoding = self
+            .tokenizer
+            .encode(text, true)
+            .map_err(|e| anyhow::anyhow!("Failed to encode text: {:?}", e))?;
+        Ok(encoding.get_ids().len())
     }
 }


### PR DESCRIPTION
Hey! Great project — thanks for building this!                                                                                                                                                                       
                                                                                                                                                                                                                       
I ran into a runtime crash caused by a protobuf version mismatch between sentencepiece-sys (v3.14.0) and onnxruntime (v3.21.12):                                                                                     
        
```                                                                                                                                                                                                  
  [libprotobuf FATAL ...common.cc:83] This program was compiled against version 3.14.0                                                                                                                                 
  of the Protocol Buffer runtime library, which is not compatible with the installed                                                                                                                                   
  version (3.21.12). Contact the program author for an update.                                                                                                                                                         
  (Version verification failed in ".../sentencepiece-sys-0.13.1/source/src/builtin_pb/sentencepiece_model.pb.cc".)                                                                                                     
  libc++abi: terminating due to uncaught exception of type google::protobuf::FatalException                                                                                                                            
```  
                                                                                                                                                                                                                     
  Since both crates link against protobuf's C++ runtime at different versions, they can't coexist in the same binary. This PR resolves the issue by removing sentencepiece entirely and using the tokenizers crate     
  (already a dependency for WASM) on all platforms.                                                                                                                                                                    
                                                                                                                                                                                                                       
# What changed                                                                                                                                                                                                         
                                                                                                                                                                                                                       
  - Removed sentencepiece dependency from Cargo.toml, eliminating the protobuf C++ conflict                                                                                                                            
  - Unified native and WASM code paths in LUTConditioner — removed all #[cfg(target_arch = "wasm32")] gates                                                                                                            
  - Added a lightweight SentencePiece .model parser that extracts the vocab from the protobuf binary and builds a tokenizers::Unigram model, so existing .model files continue to work seamlessly                      
                                                                                                                                                                                                                       
#  Why this approach                                                                                                                                                                                                    
                                                                                                                                                                                                                       
  The tokenizers crate from Hugging Face is a pure Rust implementation with no C++ protobuf dependency. Since it was already used for the WASM target, extending it to native targets was straightforward. The manual  
  protobuf parser only needs to read the vocabulary entries, keeping it minimal and focused.                                                                                                                           
                                                                                                                                                                                                                       
  Happy to adjust anything — let me know what you think!