### PR TITLE
fix: make all SDPA tensors contiguous before matmul

### DIFF
--- a/crates/pocket-tts/src/modules/sdpa.rs
+++ b/crates/pocket-tts/src/modules/sdpa.rs
@@ -42,6 +42,8 @@ pub fn sdpa(
     context_window: Option<usize>,
 ) -> Result<Tensor> {
     let q = q.contiguous()?;
+    let k = k.contiguous()?;
+    let v = v.contiguous()?;
     let (_b, _h, q_len, _dim) = q.dims4()?;
     let kv_len = k.dims()[2];
 
@@ -51,7 +53,7 @@ pub fn sdpa(
     // Benchmark showed naive is faster for Q=1 and comparable for Q=50/64.
     const TILING_THRESHOLD: usize = 512;
 
-    let k_t = k.transpose(2, 3)?; // [B, H, D, S]
+    let k_t = k.transpose(2, 3)?.contiguous()?; // [B, H, D, S]
 
     if q_len < TILING_THRESHOLD {
         // Naive path (no tiling)
@@ -75,7 +77,7 @@ pub fn sdpa(
         };
 
         let probs = candle_nn::ops::softmax(&scores, D::Minus1)?;
-        return probs.matmul(v);
+        return probs.matmul(&v);
     }
 
     // Tiled path for large Q
@@ -114,7 +116,7 @@ pub fn sdpa(
         let probs = candle_nn::ops::softmax(&scores, D::Minus1)?;
 
         // Output chunk: [B, H, Block, D] = [B, H, Block, S] @ [B, H, S, D]
-        let out_chunk = probs.matmul(v)?;
+        let out_chunk = probs.matmul(&v)?;
 
         outputs.push(out_chunk);
     }
@@ -188,9 +190,19 @@ pub fn sdpa_chunked(
     let q = q.contiguous()?;
     let (b, h, q_len, d) = q.dims4()?;
 
+    // Ensure all KV chunks are contiguous for CPU matmul compatibility
+    let k_chunks: Vec<Tensor> = k_chunks
+        .iter()
+        .map(|t| t.contiguous())
+        .collect::<Result<_>>()?;
+    let v_chunks: Vec<Tensor> = v_chunks
+        .iter()
+        .map(|t| t.contiguous())
+        .collect::<Result<_>>()?;
+
     // Fast path for single chunk
     if k_chunks.len() == 1 {
-        let k_t = k_chunks[0].transpose(2, 3)?;
+        let k_t = k_chunks[0].transpose(2, 3)?.contiguous()?;
         let scores = (q.matmul(&k_t)? * scale)?;
         let kv_len = k_chunks[0].dims()[2];
 
@@ -222,7 +234,7 @@ pub fn sdpa_chunked(
 
     for k_chunk in k_chunks {
         total_kv_len += k_chunk.dims()[2];
-        let k_t = k_chunk.transpose(2, 3)?;
+        let k_t = k_chunk.transpose(2, 3)?.contiguous()?;
         let score_chunk = (q.matmul(&k_t)? * scale)?;
         score_chunks.push(score_chunk);
     }
@@ -259,7 +271,7 @@ pub fn sdpa_chunked(
     for v_chunk in v_chunks {
         let chunk_len = v_chunk.dims()[2];
         let probs_chunk = probs.narrow(3, offset, chunk_len)?;
-        let out_chunk = probs_chunk.matmul(v_chunk)?;
+        let out_chunk = probs_chunk.matmul(&v_chunk)?;
         output = (output + out_chunk)?;
         offset += chunk_len;
     }


### PR DESCRIPTION
Hi, thanks for looking at my other PR! When I was testing voice cloning with WAV files on Linux (CPU backend), I ran into a `MatMulUnexpectedStriding("non-contiguous rhs")` crash during the Mimi encoder's attention pass.

This only triggers during voice cloning because the Mimi encoder processes long WAV sequences (~1600 KV positions from 30s audio). Normal TTS uses short step-by-step decoding where tensors happen to stay contiguous.

Error:
```
  MatMulUnexpectedStriding {
    lhs_l: Layout { shape: [1, 8, 128, 64], stride: [819200, 102400, 64, 1] },
    rhs_l: Layout { shape: [1, 8, 64, 1600], stride: [819200, 64, 1, 512] },
    msg: "non-contiguous rhs"
  }
```

# What changed:

- Added .contiguous() calls for all inputs (Q, K, V) at the top of sdpa() and sdpa_chunked() in crates/pocket-tts/src/modules/sdpa.rs.

- Two sources of non-contiguous tensors:
  - K after transpose — k.transpose(2, 3) swaps strides without copying data, so the memory layout no longer matches the logical shape
  - V from KV cache — V can be a non-contiguous slice/view from the KV cache buffer

# Why it crashes on CPU (Linux/Intel) but not Metal (Mac):

A tensor's data can be physically scattered in memory even though it looks like a normal matrix. Operations like transpose and narrow (slicing) don't move any data — they just change how indices  map to memory locations (via "strides"). CPU matmul implementations (BLAS routines) are optimized to read data in sequential sweeps through memory. When the data is scattered due to transposed/sliced strides, the routine can't just step through memory linearly — it would read wrong values or out-of-bounds memory. Rather than silently producing garbage, candle detects this upfront and aborts with MatMulUnexpectedStriding.

Metal GPU shaders don't have this limitation — they take stride parameters directly and can read from arbitrary memory layouts natively, so the same non-contiguous tensors work fine on Mac.

# Why this approach:

  .contiguous() copies the data into sequential layout when needed. If the data is already sequential, it's a no-op — just a cheap stride check, no copy.

  Rather than adding .contiguous() before each individual matmul call, ensuring all inputs are contiguous upfront is simpler and catches any future matmul additions too. Since it's a no-op for already-sequential tensors, there's no performance impact on the normal TTS path.