### PR TITLE
Fix generation on metal device

### DIFF
--- a/crates/pocket-tts/src/modules/sdpa.rs
+++ b/crates/pocket-tts/src/modules/sdpa.rs
@@ -270,7 +270,7 @@ pub fn sdpa_chunked(
     let mut offset = 0;
     for v_chunk in v_chunks {
         let chunk_len = v_chunk.dims()[2];
-        let probs_chunk = probs.narrow(3, offset, chunk_len)?;
+        let probs_chunk = probs.narrow(3, offset, chunk_len)?.contiguous()?;
         let out_chunk = probs_chunk.matmul(&v_chunk)?;
         output = (output + out_chunk)?;
         offset += chunk_len;


### PR DESCRIPTION
What happens: In sdpa_chunked(), when multiple KV chunks exist, all attention scores are concatenated into a single probs tensor (e.g., shape [1, 8, 16, 32]), then probs.narrow(3, offset, chunk_len) slices it per-chunk for the weighted sum with V.

The narrow on the last dimension creates a non-contiguous view — shape [1, 8, 16, 16] but stride 32 in the penultimate dimension (from the original total KV length).

Why it only crashes on Metal: The Metal MLX GEMM kernel requires either row-major or transposed-contiguous strides.
A stride of 32 where 16 is expected (lhs_m2 == k fails: 32 ≠ 16) doesn't match either pattern. The CPU BLAS implementation handles arbitrary strides.

When it triggers: On the second Mimi decoder step onward, when the windowed attention has cached KV entries from a previous step, producing 2+ KV chunks. The Mimi upsample stride of 16 (24kHz / hop_length_120 / frame_rate_12.5) means q_len=16 > 1, which prevents the m == 1 special case from saving it.