### PR TITLE
Fallback to public model weights on gated repo auth failure when privileged HF token is not supplied.

### DIFF
--- a/crates/pocket-tts/src/tts_model.rs
+++ b/crates/pocket-tts/src/tts_model.rs
@@ -196,7 +196,19 @@ impl TTSModel {
                 .weights_path
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("weights_path not specified in config"))?;
-            let weights_file = crate::weights::download_if_necessary(weights_path)?;
+            let weights_result = crate::weights::download_if_necessary(weights_path);
+            let weights_file = match weights_result {
+                Ok(p) => p,
+                Err(e) => {
+                    println!("Gated weights failed: {}", e);
+                    let fallback_path = config
+                        .weights_path_without_voice_cloning
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("No fallback weights path available"))?;
+                    println!("Falling back to public version without voice cloning");
+                    crate::weights::download_if_necessary(fallback_path)?
+                }
+            };
 
             // Load safetensors with VarBuilder
             let vb =


### PR DESCRIPTION
This PR adds automatic fallback from the gated `kyutai/pocket-tts` HF repo to the public `kyutai/pocket-tts-without-voice-cloning` one when the initial HF cache download fails, e. g. HTTP 401 Unauthorized.  
From looking at the code and config, it seems like such a fallback was intended but never implemented so far outside of Dockerfile.  
The config YAML file `crates/pocket-tts/config/b6369a24.yaml` already defines both `weights_path` and `weights_path_without_voice_cloning`, but the latter is presently never used.  
Without a privileged HF token provided, the program is unable to start in the current state, halting with HF HTTP 401.  

With this PR merged, it will work out of the box: clone, build, run as usual.  
Resolves #18.  
Does not conflict with #16.  

I leave the phrasing of readme adjustments, if any are necessary to detail why voice cloning may fail in case of the fallback, and advancement of version numbers to the maintainer.  