### PR TITLE
Add Metal support for server command

### DIFF
--- a/crates/pocket-tts-cli/src/commands/serve.rs
+++ b/crates/pocket-tts-cli/src/commands/serve.rs
@@ -60,6 +60,10 @@ pub struct ServeArgs {
     #[arg(long)]
     pub quantized: bool,
 
+    /// Use Metal acceleration (macOS only)
+    #[arg(long)]
+    pub use_metal: bool,
+
     /// Maximum number of resolved voice states to keep in server LRU cache.
     #[arg(long, default_value_t = 64)]
     pub voice_cache_capacity: usize,

--- a/crates/pocket-tts-cli/src/commands/wasm_demo.rs
+++ b/crates/pocket-tts-cli/src/commands/wasm_demo.rs
@@ -41,6 +41,7 @@ pub async fn run(args: WasmDemoArgs) -> Result<()> {
         lsd_decode_steps: 1,
         eos_threshold: -4.0,
         quantized: false,
+        use_metal: false,
         voice_cache_capacity: 64,
         prewarm_voices: "alba".to_string(),
         warmup: true,

--- a/crates/pocket-tts-cli/src/server/mod.rs
+++ b/crates/pocket-tts-cli/src/server/mod.rs
@@ -48,15 +48,31 @@ pub async fn start_server(args: ServeArgs) -> Result<()> {
         println!("  Set MKL_NUM_THREADS={mkl_threads}");
     }
 
+    let device = if args.use_metal {
+        #[cfg(feature = "metal")]
+        {
+            candle_core::Device::new_metal(0)?
+        }
+        #[cfg(not(feature = "metal"))]
+        {
+            anyhow::bail!("Metal feature not enabled. Rebuild with --features metal");
+        }
+    } else {
+        candle_core::Device::Cpu
+    };
+    println!("  Using device: {:?}", device);
+
     // Load model with configured parameters
     let model = if args.quantized {
         #[cfg(feature = "quantized")]
         {
-            TTSModel::load_quantized_with_params(
+            TTSModel::load_quantized_with_params_device(
                 &args.variant,
                 args.temperature,
                 args.lsd_decode_steps,
                 args.eos_threshold,
+                None,
+                &device,
             )?
         }
         #[cfg(not(feature = "quantized"))]
@@ -64,11 +80,13 @@ pub async fn start_server(args: ServeArgs) -> Result<()> {
             anyhow::bail!("Quantization feature not enabled. Rebuild with --features quantized");
         }
     } else {
-        TTSModel::load_with_params(
+        TTSModel::load_with_params_device(
             &args.variant,
             args.temperature,
             args.lsd_decode_steps,
             args.eos_threshold,
+            None,
+            &device,
         )?
     };
 

--- a/crates/pocket-tts-cli/web/vite.config.ts
+++ b/crates/pocket-tts-cli/web/vite.config.ts
@@ -3,6 +3,8 @@ import tailwindcss from "@tailwindcss/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
+const apiTarget = process.env.POCKET_TTS_API_BASE || "http://localhost:8000"
+
 // https://vite.dev/config/
 export default defineConfig({
   base: "./",
@@ -14,10 +16,10 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/stream': 'http://localhost:3000',
-      '/generate': 'http://localhost:3000',
-      '/health': 'http://localhost:3000',
-      '/wasm': 'http://localhost:3000',
+      '/stream': apiTarget,
+      '/generate': apiTarget,
+      '/health': apiTarget,
+      '/wasm': apiTarget,
     }
   }
 })

--- a/crates/pocket-tts/src/weights.rs
+++ b/crates/pocket-tts/src/weights.rs
@@ -41,6 +41,7 @@ pub fn download_if_necessary(file_path: &str) -> Result<PathBuf> {
         let token = std::env::var("HF_TOKEN").ok();
 
         let api = ApiBuilder::new().with_token(token).build()?;
+        let repo_display = repo_id.clone();
 
         // Create repo with or without revision
         let repo = if let Some(rev) = revision {
@@ -50,7 +51,16 @@ pub fn download_if_necessary(file_path: &str) -> Result<PathBuf> {
         };
 
         let api_repo = api.repo(repo);
-        let path = api_repo.get(&filename)?;
+        let path = api_repo.get(&filename).map_err(|err| {
+            let auth_hint = if std::env::var_os("HF_TOKEN").is_some() {
+                "HF_TOKEN is set, but HuggingFace rejected the request. Check that the token is valid and has access to the gated kyutai/pocket-tts model."
+            } else {
+                "HF_TOKEN is not set. Request access to kyutai/pocket-tts on HuggingFace, then run with HF_TOKEN=<your_token> in the environment."
+            };
+            anyhow::anyhow!(
+                "failed to download HuggingFace file '{filename}' from '{repo_display}': {err}. {auth_hint}"
+            )
+        })?;
         Ok(path)
     } else {
         Ok(PathBuf::from(file_path))


### PR DESCRIPTION
## Summary

- Add `--use-metal` support to the `serve` command, matching the existing `generate --use-metal` behavior.
- Load the server model on the selected device for both regular and quantized paths.
- Update the Vite dev proxy default to the Rust server’s default port (`8000`) and allow overriding it with `POCKET_TTS_API_BASE`.
- Improve HuggingFace download errors for gated model access / `HF_TOKEN` issues.

## Validation

Tested locally on:
- MacBook Pro, Apple M3 Max
- macOS 26.3.1

Checks run:
- `cargo fmt --check`
- `cargo check --release --features metal --package pocket-tts-cli`
- `npm run build`
